### PR TITLE
fix subjob redis multi pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,9 +22,9 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/rails_5_sidekiq_5.gemfile
-#          - gemfiles/rails_5_sidekiq_6.gemfile
+          - gemfiles/rails_5_sidekiq_6.gemfile
           - gemfiles/rails_6_sidekiq_5.gemfile
-#          - gemfiles/rails_6_sidekiq_6.gemfile
+          - gemfiles/rails_6_sidekiq_6.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - Unreleased
+### Changed
+* Cleanup usage of Redis#multi to not use different connections while within the `multi` block.
+* Allow support for sidekiq 6.
+
 ## [1.2.2] - 2023-02-23
 ### Changed
 * Limit required version of sidekiq, activesupport, and activemodel to >= 5, < 6.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    sidekiq-superworker (1.2.2)
+    sidekiq-superworker (1.2.3)
       activemodel (>= 5.0, < 7)
       activesupport (>= 5.0, < 7)
-      sidekiq (>= 5.0, < 6)
+      sidekiq (>= 5.0, < 7)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/sidekiq/superworker/subjob.rb
+++ b/lib/sidekiq/superworker/subjob.rb
@@ -85,6 +85,16 @@ module Sidekiq
           Superworker.options[:subjob_redis_prefix]
         end
 
+        def redis_connection(&block)
+          if (connection = redis_connection_for_transaction)
+            yield connection
+          else
+            Sidekiq.redis(&block)
+          end
+        end
+
+        private
+
         def create_redis_multi_pipeline(&block)
           result = nil
           Sidekiq.redis do |conn|
@@ -104,14 +114,6 @@ module Sidekiq
 
         def redis_connection_for_transaction
           Thread.current[:redis_connection_for_transaction]
-        end
-
-        def redis_connection(&block)
-          if (connection = redis_connection_for_transaction)
-            yield connection
-          else
-            Sidekiq.redis(&block)
-          end
         end
       end
 

--- a/lib/sidekiq/superworker/version.rb
+++ b/lib/sidekiq/superworker/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Superworker
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
   end
 end

--- a/sidekiq-superworker.gemspec
+++ b/sidekiq-superworker.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.metadata["allowed_push_host"] = "https://gem.fury.io/invoca"
 
-  s.add_dependency 'sidekiq', '>= 5.0', '< 6'
+  s.add_dependency 'sidekiq', '>= 5.0', '< 7'
   s.add_dependency 'activesupport', '>= 5.0', '< 7'
   s.add_dependency 'activemodel', '>= 5.0', '< 7'
 end


### PR DESCRIPTION
Redis gem version > 4.5 doesn't allow for using different Redis connections while within a `Redis.multi |pipeline|` block.

The main fix here is to ensure we always use the connection that is passed to us when calling `Redis.multi`.